### PR TITLE
Fix top page posts retrieval and cleanup Post model

### DIFF
--- a/app/Http/Controllers/TopController.php
+++ b/app/Http/Controllers/TopController.php
@@ -31,7 +31,7 @@ class TopController extends Controller
         // カテゴリーを取得
         $categories = $this->category->getAllCategories();
         // 投稿を取得
-        $posts = $this->post->getAllPostsByUserId($user_id);
+        $posts = $this->post->getPostsSortByLatestUpdate();
 
         return view('top', compact(
             'user_id',
@@ -53,7 +53,7 @@ class TopController extends Controller
         // カテゴリーを全て取得
         $categories = $this->category->getAllCategories();
         // 記事IDをもとに特定の記事のデータを取得
-        $post = $this->post->feachPostDateByPostId($post_id);
+        $post = $this->post->fetchPostDataByPostId($post_id);
         return view('article.show', compact(
             'user_id',
             'categories',

--- a/app/Http/Controllers/User/PostController.php
+++ b/app/Http/Controllers/User/PostController.php
@@ -76,7 +76,7 @@ class PostController extends Controller
      */
     public function show($post_id) {
         // リクエストされた投稿IDをもとにpostsテーブルから一意のデータを取得
-        $post = $this->post->feachPostDateByPostId($post_id);
+        $post = $this->post->fetchPostDataByPostId($post_id);
         return view('user.list.show', compact(
             'post',
         ));

--- a/app/Models/Post.php
+++ b/app/Models/Post.php
@@ -75,17 +75,6 @@ class Post extends Model
         return $result;
     }
 
-    /**
-     * 投稿IDをもとにpostsテーブルから一意の投稿データを取得
-     * 
-     * @param int $post_id 投稿ID
-     * @return object $result App\Models\Post
-     */
-    public function feachPostDateByPostId($post_id)
-    {
-        $result = $this->find($post_id);
-        return $result;
-    }
 
     /**
      * カテゴリーIDに紐づいた投稿リストを全て取得する


### PR DESCRIPTION
## Summary
- show latest posts on the top page regardless of login
- use correct `fetchPostDataByPostId` method in controllers
- remove duplicate `feachPostDateByPostId` method from Post model

## Testing
- `./vendor/bin/phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f93c1d3a083308f3f2f8dfb428d73